### PR TITLE
feat(inputs): add new vars `TRIAGE_*`

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -10,6 +10,16 @@ on:
         required: true
         description: What project to triage issues/pr for
         type: string
+      TRIAGE_EVENT_ACTION:
+        required: false
+        default: "${{ github.event.action }}"
+        description: Event action that triggered to workflow
+        type: string
+      TRIAGE_EVENT_NAME:
+        required: false
+        default: "${{ github.event_name }}"
+        description: Name of event that triggered to workflow
+        type: string
     secrets:
       WORKFLOW_TOKEN:
         description: Token used to with permission to the project
@@ -32,43 +42,46 @@ jobs:
           echo "[Debug] github.event.pull_request.author_association=${{ github.event.pull_request.author_association }}";
           echo "[Debug] github.triggering_actor=${{ github.triggering_actor }}";
 
+          echo "[Debug] inputs.TRIAGE_EVENT_ACTION=${{ inputs.TRIAGE_EVENT_ACTION }}";
+          echo "[Debug] inputs.TRIAGE_EVENT_NAME=${{ inputs.TRIAGE_EVENT_NAME }}";
+
 
   project-add:
     name: Add
     if: ${{(
       (
-        github.event_name == 'issues'
+        inputs.TRIAGE_EVENT_NAME == 'issues'
           &&
         (
-          github.event.action == 'opened'
+          inputs.TRIAGE_EVENT_ACTION == 'opened'
             ||
-          github.event.action == 'reopened'
+          inputs.TRIAGE_EVENT_ACTION == 'reopened'
             ||
-          github.event.action == 'labeled'
+          inputs.TRIAGE_EVENT_ACTION == 'labeled'
             ||
-          github.event.action == 'milestoned'
+          inputs.TRIAGE_EVENT_ACTION == 'milestoned'
             ||
-          github.event.action == 'demilestoned'
+          inputs.TRIAGE_EVENT_ACTION == 'demilestoned'
             ||
-          github.event.action == 'closed'
+          inputs.TRIAGE_EVENT_ACTION == 'closed'
             ||
-          github.event.action == 'assigned'
+          inputs.TRIAGE_EVENT_ACTION == 'assigned'
         )
       )
         ||
       (
-        github.event_name == 'pull_request'
+        inputs.TRIAGE_EVENT_NAME == 'pull_request'
           &&
         (
-          github.event.action == 'opened'
+          inputs.TRIAGE_EVENT_ACTION == 'opened'
             ||
-          github.event.action == 'edited'
+          inputs.TRIAGE_EVENT_ACTION == 'edited'
             ||
-          github.event.action == 'assigned'
+          inputs.TRIAGE_EVENT_ACTION == 'assigned'
             ||
-          github.event.action == 'reopened'
+          inputs.TRIAGE_EVENT_ACTION == 'reopened'
             ||
-          github.event.action == 'closed'
+          inputs.TRIAGE_EVENT_ACTION == 'closed'
         )
       )
       )}}
@@ -85,7 +98,7 @@ jobs:
   project-remove:
     name: Remove
     if: ${{(
-        github.event_name == 'issues' && github.event.action == 'transferred'
+        inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'transferred'
       )}}
     runs-on: ubuntu-latest
     steps:
@@ -99,9 +112,9 @@ jobs:
   project-fields:
     name: Field Values
     if: ${{(
-        (github.event_name == 'issues' && github.event.action != 'transferred')
+        (inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION != 'transferred')
           ||
-        (github.event_name == 'pull_request')
+        (inputs.TRIAGE_EVENT_NAME == 'pull_request')
       )}}
     needs:
       - project-add
@@ -155,9 +168,9 @@ jobs:
     name: Set Start Date
     if: ${{(
         (
-          (github.event_name == 'issues' && github.event.action == 'assigned')
+          (inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'assigned')
             ||
-          github.event_name == 'pull_request'
+          inputs.TRIAGE_EVENT_NAME == 'pull_request'
         )
           &&
         needs.project-fields.outputs.project-start-date == ''
@@ -193,7 +206,7 @@ jobs:
 
 
       - name: Set Status Planning
-        if: ${{ github.event_name == 'issues' && github.event.action == 'milestoned' }}
+        if: ${{ inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'milestoned' }}
         uses: EndBug/project-fields@v2
         with:
           operation: set
@@ -205,9 +218,9 @@ jobs:
 
       - name: Set Status In Progress
         if: ${{(
-            (github.event_name == 'issues' && github.event.action == 'assigned')
+            (inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'assigned')
               ||
-            github.event_name == 'pull_request' && github.event.action != 'closed'
+            inputs.TRIAGE_EVENT_NAME == 'pull_request' && inputs.TRIAGE_EVENT_ACTION != 'closed'
           )}}
         uses: EndBug/project-fields@v2
         with:
@@ -219,7 +232,7 @@ jobs:
 
 
       - name: Set Status done
-        if: ${{ github.event.action == 'closed' }}
+        if: ${{ inputs.TRIAGE_EVENT_ACTION == 'closed' }}
         uses: EndBug/project-fields@v2
         with:
           operation: set
@@ -232,9 +245,9 @@ jobs:
       - name: Clear Status
         if: ${{(
             (
-              (github.event_name == 'issues' && github.event.action == 'reopened')
+              (inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'reopened')
                 ||
-              (github.event_name == 'issues' && github.event.action == 'demilestoned')
+              (inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'demilestoned')
             ) 
             &&
             needs.project_fields.project-status != 'Ready to Commence'
@@ -254,9 +267,9 @@ jobs:
         needs.project-fields.outputs.project-start-date != ''
           &&
         (
-          github.event.action == 'closed'
+          inputs.TRIAGE_EVENT_ACTION == 'closed'
             ||
-          github.event.action == 'reopened'
+          inputs.TRIAGE_EVENT_ACTION == 'reopened'
         )
       )}}
     needs:
@@ -267,7 +280,7 @@ jobs:
 
       - name: Set End date
         if: ${{(
-            github.event.action == 'closed'
+            inputs.TRIAGE_EVENT_ACTION == 'closed'
               &&
             needs.project-fields.outputs.project-end-date == ''
           )}}
@@ -282,7 +295,7 @@ jobs:
 
       - name: Clear End Date
         if: ${{(
-            github.event_name == 'issues' && github.event.action == 'reopened'
+            inputs.TRIAGE_EVENT_NAME == 'issues' && inputs.TRIAGE_EVENT_ACTION == 'reopened'
           )}}
         uses: EndBug/project-fields@v2
         with:

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -20,6 +20,11 @@ on:
         default: "${{ github.event_name }}"
         description: Name of event that triggered to workflow
         type: string
+      TRIAGE_ITEM_NUMBER:
+        required: false
+        default: 0
+        description: Number of the item that triggered the workflow (issue/PR)
+        type: number
       TRIAGE_ITEM_URL:
         required: false
         default: "none"

--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -20,6 +20,11 @@ on:
         default: "${{ github.event_name }}"
         description: Name of event that triggered to workflow
         type: string
+      TRIAGE_ITEM_URL:
+        required: false
+        default: "none"
+        description: URL of the item that triggered the workflow (issue/PR)
+        type: string
     secrets:
       WORKFLOW_TOKEN:
         description: Token used to with permission to the project
@@ -46,8 +51,42 @@ jobs:
           echo "[Debug] inputs.TRIAGE_EVENT_NAME=${{ inputs.TRIAGE_EVENT_NAME }}";
 
 
+  prepare:
+    name: Preparation
+    runs-on: ubuntu-latest
+    outputs:
+      triage_item_url: ${{ steps.triage_item_url.outputs.triage_item_url }}
+    steps:
+
+
+      - name: Build Item URL
+        id: triage_item_url
+        shell: bash
+        run: |
+
+          if [ "${{ inputs.TRIAGE_ITEM_URL }}" == "none" ]; then
+
+            if [ "${{inputs.TRIAGE_EVENT_NAME }}" == 'pull_request' ]; then
+
+              echo "triage_item_url=https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" > $GITHUB_OUTPUT;
+
+            else
+
+              echo "triage_item_url=https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}" > $GITHUB_OUTPUT;
+
+            fi;
+
+          else
+
+            echo "triage_item_url=${{ inputs.TRIAGE_ITEM_URL }}" > $GITHUB_OUTPUT;
+
+          fi;
+
+
   project-add:
     name: Add
+    needs:
+      - prepare
     if: ${{(
       (
         inputs.TRIAGE_EVENT_NAME == 'issues'
@@ -117,6 +156,7 @@ jobs:
         (inputs.TRIAGE_EVENT_NAME == 'pull_request')
       )}}
     needs:
+      - prepare
       - project-add
     runs-on: ubuntu-latest
     outputs:
@@ -141,6 +181,7 @@ jobs:
           fields: Start date
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
 
 
       - name: Fetch End Date
@@ -151,6 +192,7 @@ jobs:
           fields: End date
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
 
 
       - name: Fetch Status
@@ -161,6 +203,7 @@ jobs:
           fields: Status
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
 
 
 
@@ -176,6 +219,7 @@ jobs:
         needs.project-fields.outputs.project-start-date == ''
       )}}
     needs:
+      - prepare
       - project-fields
     runs-on: ubuntu-latest
     steps:
@@ -188,6 +232,7 @@ jobs:
           fields: Start date
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
           values: ${{ needs.project-fields.outputs.date-value }} 
 
 
@@ -200,6 +245,7 @@ jobs:
         needs.project-fields.outputs.project-status != 'In progress'
       )}}
     needs:
+      - prepare
       - project-fields
     runs-on: ubuntu-latest
     steps:
@@ -213,6 +259,7 @@ jobs:
           fields: Status
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
           values: 'Planning'
 
 
@@ -228,6 +275,7 @@ jobs:
           fields: Status
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
           values: 'In progress'
 
 
@@ -239,6 +287,7 @@ jobs:
           fields: Status
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
           values: 'Done'
 
 
@@ -258,6 +307,7 @@ jobs:
           fields: Status
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
 
 
 
@@ -273,6 +323,7 @@ jobs:
         )
       )}}
     needs:
+      - prepare
       - project-fields
     runs-on: ubuntu-latest
     steps:
@@ -290,6 +341,7 @@ jobs:
           fields: End date
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}
           values: ${{ needs.project-fields.outputs.date-value }} 
 
 
@@ -303,3 +355,4 @@ jobs:
           fields: End date
           github_token: ${{ secrets.WORKFLOW_TOKEN }}
           project_url: ${{ inputs.PROJECT_URL }}
+          resource_url: ${{ needs.prepare.outputs.triage_item_url }}


### PR DESCRIPTION
work in preparation for solution 1 on #3

## Problem

There does not appear to be a way to specify the item url for action `actions/add-to-project`

- ref: https://github.com/actions/add-to-project/pull/341

    _Adds feature that allows specifying via payload_
 

## Links

- Related #3


## Tasks

- [ ] Specify item ID/URL for action `actions/add-to-project`

